### PR TITLE
Add plan44/vdcd and plan44/p44mbrd to project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Check them out and get inspired! 🚀🔧
 
 - [rolfscherer/wiser-matter-bridge (GitHub) 🔗](https://github.com/rolfscherer/wiser-matter-bridge)
 
+### plan44 matter+DS gateway
+
+- [plan44/vdcd automation daemon (github) 🔗](https://github.com/plan44/vdcd)
+- [plan44/p44mbrd matter bridge (github) 🔗](https://github.com/plan44/p44mbrd)
+
 ### Python
 
 - [Syonix/aioWiserByFeller (GitHub) 🔗](https://github.com/Syonix/aioWiserByFeller)


### PR DESCRIPTION
Links to the two GPLv3 components of the Wiser-by-Feller to matter (and DigitalStrom) bridge.

The full stack OpenWrt build https://github.com/plan44/p44-xx-open is not yet updated to include the newer version of vdcd and related WebUI for Wiser-by-Feller, so I'm leaving it out for now until I find time to update everything.